### PR TITLE
Weighted fitting and block elimation [Closes #4 and 

### DIFF
--- a/examples/test_fitting.jl
+++ b/examples/test_fitting.jl
@@ -6,14 +6,15 @@ using Random
 using Statistics
 using StructuredGaussianMixtures
 using Plots
+using StatProfilerHTML
 
-function mc_kl(p, q, n_samples=10000)
+function mc_kl(p, q, n_samples=1000)
     samples = rand(p, n_samples)
     log_p = logpdf(p, samples)
     log_q = logpdf(q, samples)
     return mean(log_p .- log_q)
 end
-mc_jsd(p, q, n_samples=10000) = 0.5*(mc_kl(p, q, n_samples) + mc_kl(q, p, n_samples))
+mc_jsd(p, q, n_samples=1000) = 0.5*(mc_kl(p, q, n_samples) + mc_kl(q, p, n_samples))
 
 function compare_methods_pca(true_gmm, n_components, n_rank; run_pca=true, n_samples=1000)
     data = rand(true_gmm, n_samples)
@@ -36,6 +37,19 @@ function compare_methods_pca(true_gmm, n_components, n_rank; run_pca=true, n_sam
     @time gmm_factor = StructuredGaussianMixtures.fit(fitmethod, data)
     gmm_factor_samples = rand(gmm_factor, n_samples)
 
+
+    # print the JSD between the true model and the three models
+    test_data = rand(true_gmm, n_samples÷5)
+    println("EM Avg. Training LL: ", mean(logpdf(gmm_full, data)))
+    println("PCAEM Avg. Training LL: ", mean(logpdf(gmm_pca, data)))
+    println("FactorEM Avg. Training LL: ", mean(logpdf(gmm_factor, data)))
+    println("EM Avg. Test LL: ", mean(logpdf(gmm_full, test_data)))
+    println("PCAEM Avg. Test LL: ", mean(logpdf(gmm_pca, test_data)))
+    println("FactorEM Avg. Test LL: ", mean(logpdf(gmm_factor, test_data)))
+    println("EM|True JSD: ", mc_jsd(true_gmm, gmm_full))
+    println("PCAEM|True JSD: ", mc_jsd(true_gmm, gmm_pca))
+    println("FactorEM|True JSD: ", mc_jsd(true_gmm, gmm_factor))
+
     # plot samples from the three models
     if run_pca
         pca = MultivariateStats.fit(PCA, data; maxoutdim=2);
@@ -45,32 +59,36 @@ function compare_methods_pca(true_gmm, n_components, n_rank; run_pca=true, n_sam
         gmm_factor_samples = transform(pca, gmm_factor_samples)
     end
 
-    # print the JSD between the true model and the three models
-    println("EM JSD: ", mc_jsd(true_gmm, gmm_full))
-    println("PCAEM JSD: ", mc_jsd(true_gmm, gmm_pca))
-    println("FactorEM JSD: ", mc_jsd(true_gmm, gmm_factor))
-
     # Create scatter plots of the three models
     xlabel = run_pca ? "PC1" : "Feature 1"
     ylabel = run_pca ? "PC2" : "Feature 2"
     p1 = scatter(data[1, :], data[2, :], 
                 alpha=0.6, title="True Model", xlabel=xlabel, ylabel=ylabel, 
                 label="True samples", markersize=2, margin=5Plots.mm)
+    
+    # Get axis limits from p1
+    x_lims = xlims(p1)
+    y_lims = ylims(p1)
+    
     p2 = scatter(gmm_full_samples[1, :], gmm_full_samples[2, :], 
                 alpha=0.6, title="EM Model", xlabel=xlabel, ylabel=ylabel, 
-                label="EM samples", markersize=2, margin=5Plots.mm)
+                label="EM samples", markersize=2, margin=5Plots.mm,
+                xlims=x_lims, ylims=y_lims)
     p3 = scatter(gmm_pca_samples[1, :], gmm_pca_samples[2, :], 
                 alpha=0.6, title="PCAEM Model", xlabel=xlabel, ylabel=ylabel, 
-                label="PCAEM samples", markersize=2, margin=5Plots.mm)
+                label="PCAEM samples", markersize=2, margin=5Plots.mm,
+                xlims=x_lims, ylims=y_lims)
     p4 = scatter(gmm_factor_samples[1, :], gmm_factor_samples[2, :], 
                 alpha=0.6, title="FactorEM Model", xlabel=xlabel, ylabel=ylabel, 
-                label="FactorEM samples", markersize=2, margin=5Plots.mm)
+                label="FactorEM samples", markersize=2, margin=5Plots.mm,
+                xlims=x_lims, ylims=y_lims)
 
     # Combine all plots
     return plot(p1, p2, p3, p4, layout=(1, 4), size=(1600, 400))
 end
 
 # Full-rank 2D GMM with potentially overlapping components
+Random.seed!(1)
 n_features = 2
 n_components = 5
 n_rank = 1
@@ -83,6 +101,7 @@ true_gmm = MixtureModel(MvNormal.(true_means, true_covs), true_probs)
 compare_methods_pca(true_gmm, n_components, n_rank; run_pca=false)
 
 # Low-Rank GMM with tied component ranks
+Random.seed!(1)
 n_rank = 2
 n_features = 400
 n_components = 3
@@ -97,6 +116,7 @@ true_gmm = MixtureModel(MvNormal.(true_means, true_covs), true_probs)
 compare_methods_pca(true_gmm, n_components, n_rank; run_pca=true)
 
 # Low-Rank GMM with independent component ranks
+Random.seed!(1)
 n_rank = 2
 n_features = 400
 n_components = 3

--- a/examples/test_weighted_fitting.jl
+++ b/examples/test_weighted_fitting.jl
@@ -1,0 +1,66 @@
+using GaussianMixtures
+using Distributions
+using LinearAlgebra
+using MultivariateStats
+using Random
+using Statistics
+using StructuredGaussianMixtures
+using Plots
+
+# Three-component GMM with specified means and weighted fitting
+Random.seed!(42)
+n_features = 2
+n_components = 3
+n_samples = 1000
+
+# Create means at (-1, -1), (0, 0), and (1, 1)
+true_means = [[-1.0, -1.0], [0.0, 0.0], [1.0, 1.0]]
+
+# Create small covariance matrices (identity scaled by 0.1)
+true_covs = [0.1^2 * Matrix{Float64}(I, n_features, n_features) for _ in 1:n_components]
+
+# Equal mixing weights
+true_probs = ones(n_components) / n_components
+
+# Create the GMM
+true_gmm = MixtureModel(MvNormal.(true_means, true_covs), true_probs)
+
+# Take 1000 samples
+data = rand(true_gmm, n_samples)
+
+# Assign weights: 1 if x1 <= 0, 0 otherwise
+weights = [data[1, i] <= 0 ? 1.0 : 0.0 for i in 1:n_samples]
+
+# Fit a 2-component rank-1 GMM using FactorEM with weights
+@info "Fitting weighted FactorEM model"
+fitmethod = FactorEM(2, 1; initialization_method=:kmeans, nInit=10, nIter=20)
+@time gmm_weighted = StructuredGaussianMixtures.fit(fitmethod, data, weights)
+
+# Print results
+println("Number of samples with weight 1: ", sum(weights))
+println("Number of samples with weight 0: ", sum(weights .== 0))
+println("Weighted FactorEM Avg. Training LL: ", mean(logpdf(gmm_weighted, data)))
+println("Weighted FactorEM Avg. Training LL (weighted): ", sum(weights .* logpdf(gmm_weighted, data)) / sum(weights))
+
+# Plot samples with different colors based on weights
+p1 = scatter(data[1, weights .== 1], data[2, weights .== 1], 
+            alpha=0.8, title="Weighted Data (x1 ≤ 0)", xlabel="x1", ylabel="x2", 
+            label="Weight = 1", markersize=4, color=:red, margin=5Plots.mm)
+scatter!(p1, data[1, weights .== 0], data[2, weights .== 0], 
+         alpha=0.3, label="Weight = 0", markersize=2, color=:gray)
+
+x_lims = xlims(p1)
+y_lims = ylims(p1)  
+
+# Generate samples from the fitted model
+gmm_samples = rand(gmm_weighted, n_samples)
+p2 = scatter(gmm_samples[1, :], gmm_samples[2, :], 
+            alpha=0.6, title="Fitted Model Samples", xlabel="x1", ylabel="x2", 
+            label="Model samples", markersize=3, margin=5Plots.mm,
+            xlims=x_lims, ylims=y_lims)
+
+
+# Combine plots
+weighted_plot = plot(p1, p2, layout=(1, 2), size=(800, 400))
+display(weighted_plot)
+

--- a/src/lrdmvnormal.jl
+++ b/src/lrdmvnormal.jl
@@ -84,12 +84,12 @@ function Distributions.logpdf(d::LRDMvNormal, x::AbstractVector)
     # det(F*F' + D) = det(D) * det(I + F'*D^(-1)*F)
     logdet_cov = sum(log.(d.D)) + logdet(I_plus_FF)
     
-    # Compute the quadratic form
-    # TODO: Solve this more efficiently with block elimination
-    precision = Diagonal(D_inv) - 
-                (F_scaled * (I_plus_FF \ F_scaled')) .* sqrt.(D_inv * D_inv')
-    quad_form = dot(x_centered, precision * x_centered)
-    
+    # Compute the quadratic form efficiently with block elimination
+    # quad_form = dot(x_centered, precision * x_centered)
+    y = (I_plus_FF \ F_scaled') * (sqrt.(D_inv) .* x_centered)
+    eta = D_inv .* (x_centered - d.F * y)
+    quad_form = dot(x_centered, eta)
+
     # Return the log PDF
     return -0.5 * (length(d.μ) * log(2π) + logdet_cov + quad_form)
 end


### PR DESCRIPTION
- Adding support for fitting weighted data using `fit(::FactorEM, data, weights)`. See `examples/test_weighted_fitting` for demo. Closes #4 
- Speeding up bottleneck in computing quad form during `logpdf` function by using block elimination. Closes #3 
- Adds log-likelihood printouts, seeding, and fixes axes limits on `test_fitting` example