### PR TITLE
fix: clamp negative eigenvalues before sqrt in LRD predict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
 /examples/Manifest.toml
+/.worktrees/

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -108,7 +108,9 @@ function predict(
     # For the low-rank part: F₂ * (I - I_plus_FF_inv) * F₂'
     # Compute matrix square root using eigendecomposition
     λ, Q = eigen(I - I_plus_FF_inv)
-    F₂_cond = F₂ * (Q * Diagonal(sqrt.(λ)))
+    # Clamp mathematically-nonnegative eigenvalues that tip slightly negative in
+    # floating point (near-saturating rank) to keep sqrt in its real domain.
+    F₂_cond = F₂ * (Q * Diagonal(sqrt.(max.(λ, 0))))
 
     # For the diagonal part: D₂ + diag(F₂ * I_plus_FF_inv * F₂')
     D₂_cond = D₂ + diag(F₂ * (I_plus_FF_inv * F₂'))

--- a/test/test_prediction.jl
+++ b/test/test_prediction.jl
@@ -131,6 +131,19 @@ using StructuredGaussianMixtures
         diag_dist = LRDMvNormal(μ, zeros(n, 0), D)
         diag_cond = predict(diag_dist, randn(5), 1:5, 6:10)
         @test length(diag_cond) == 5
+
+        # Regression test for issue #19: near-saturating rank (d=3, rank=2) can
+        # produce eigenvalues of I - I_plus_FF_inv that are mathematically ≥ 0
+        # but tip slightly negative in floating point, throwing DomainError in
+        # the unclamped sqrt. Seed 2 deterministically triggers this.
+        Random.seed!(2)
+        μ_sat = randn(3)
+        F_sat = randn(3, 2)
+        D_sat = abs.(randn(3)) .+ 1e-3
+        sat_dist = LRDMvNormal(μ_sat, F_sat, D_sat)
+        sat_x = randn(1)
+        sat_cond = predict(sat_dist, sat_x, [1], [2, 3])
+        @test length(sat_cond) == 2
     end
 
     # @testset "Numerical Stability" begin


### PR DESCRIPTION
Closes #19

## Root cause

`predict` on an `LRDMvNormal` computes the conditional low-rank factor via an
eigendecomposition of `I - I_plus_FF_inv` followed by a matrix square root
(`src/predict.jl:110-111`). When the rank nearly saturates the dimension
(e.g. `d=3`, `rank=2`), the eigenvalues of `I - I_plus_FF_inv` are
mathematically nonnegative but can tip slightly negative in floating point
(e.g. `-2.4e-14`). The unclamped `sqrt` then throws
`DomainError: sqrt was called with a negative real argument`.

## Fix

Clamp the eigenvalues at zero before the square root:
`sqrt.(max.(λ, 0))`. This is a numerical-safety change only — it does not
alter results for well-conditioned inputs, since a value like `-2.4e-14`
becomes `0`, which is the correct mathematical value.

## Regression test

Added a deterministic regression test in `test/test_prediction.jl` (Edge
Cases testset) that constructs a `d=3`, `rank=2` `LRDMvNormal` with seed 2
and conditions the 3D joint on coordinate 1 (`input_indices=[1]`,
`output_indices=[2,3]`). This reproduced the `DomainError` on the unmodified
code and asserts the returned conditional has length 2 after the fix. Full
suite passes (Prediction: 25/25, LRDMvNormal: 53/53, Fitting: 84/84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)