### PR TITLE
fix: correct LRDMvNormal predict conditional covariance

### DIFF
--- a/src/predict.jl
+++ b/src/predict.jl
@@ -104,20 +104,21 @@ function predict(
     F₁_D₁_inv = F₁ .* D₁_inv
     μ₂₁ = μ₂ + F₂ * (I_plus_FF_inv * (F₁_scaled' * (D₁_inv_sqrt .* x_centered)))
 
-    # Compute the conditional covariance structure efficiently
-    # For the low-rank part: F₂ * (I - I_plus_FF_inv) * F₂'
-    # Compute matrix square root using eigendecomposition
-    λ, Q = eigen(I - I_plus_FF_inv)
-    # Clamp mathematically-nonnegative eigenvalues that tip slightly negative in
-    # floating point (near-saturating rank) to keep sqrt in its real domain.
-    F₂_cond = F₂ * (Q * Diagonal(sqrt.(max.(λ, 0))))
-
-    # For the diagonal part: D₂ + diag(F₂ * I_plus_FF_inv * F₂')
-    D₂_cond = D₂ + diag(F₂ * (I_plus_FF_inv * F₂'))
+    # Compute the conditional covariance structure efficiently.
+    # By the Woodbury identity, the Schur complement of the joint LRD covariance is
+    #   Σ_cond = F₂ * M⁻¹ * F₂' + Diagonal(D₂),   where M = I + F₁' D₁⁻¹ F₁.
+    # Here `I_plus_FF_inv` is M⁻¹.
+    # Take a matrix square root C of M⁻¹ (M⁻¹ = C * C') so that F_cond = F₂ * C
+    # gives F_cond * F_cond' = F₂ * M⁻¹ * F₂'. Clamp eigenvalues at zero for robustness.
+    λ, Q = eigen(Symmetric(I_plus_FF_inv))
+    C = Q * Diagonal(sqrt.(max.(λ, 0)))
+    F₂_cond = F₂ * C
+    D₂_cond = D₂
 
     # Return the conditional distribution
     if length(output_indices) <= dist.rank
-        return MvNormal(μ₂₁, F₂_cond * F₂_cond' + Diagonal(D₂_cond))
+        Σ_cond = F₂_cond * F₂_cond' + Diagonal(D₂_cond)
+        return MvNormal(μ₂₁, Symmetric(Σ_cond))
     else
         return LRDMvNormal(μ₂₁, F₂_cond, D₂_cond)
     end

--- a/test/test_prediction.jl
+++ b/test/test_prediction.jl
@@ -62,6 +62,38 @@ using StructuredGaussianMixtures
         @test cond_dist_large isa LRDMvNormal
         @test length(cond_dist_large) == length(large_output)
 
+        # Test that conditional covariance matches the Schur complement
+        # Use interleaved indices to catch index-mixing bugs.
+        Σ_full = cov(dist_lrd)
+
+        # Branch returning MvNormal: length(output) <= rank
+        input_small = [1, 3, 5, 7, 9]
+        output_small = [2, 4, 6, 8, 10]
+        @test length(output_small) <= dist_lrd.rank
+        x_small = randn(length(input_small))
+        cond_small = predict(dist_lrd, x_small, input_small, output_small)
+        @test cond_small isa MvNormal
+        Σ11_s = Σ_full[input_small, input_small]
+        Σ12_s = Σ_full[input_small, output_small]
+        Σ21_s = Σ_full[output_small, input_small]
+        Σ22_s = Σ_full[output_small, output_small]
+        schur_small = Σ22_s - Σ21_s * (Σ11_s \ Σ12_s)
+        @test cov(cond_small) ≈ schur_small atol = 1e-8
+
+        # Branch returning LRDMvNormal: length(output) > rank
+        input_large = [1, 3, 5, 7, 9]
+        output_large = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        @test length(output_large) > dist_lrd.rank
+        x_large = randn(length(input_large))
+        cond_large = predict(dist_lrd, x_large, input_large, output_large)
+        @test cond_large isa LRDMvNormal
+        Σ11_l = Σ_full[input_large, input_large]
+        Σ12_l = Σ_full[input_large, output_large]
+        Σ21_l = Σ_full[output_large, input_large]
+        Σ22_l = Σ_full[output_large, output_large]
+        schur_large = Σ22_l - Σ21_l * (Σ11_l \ Σ12_l)
+        @test cov(cond_large) ≈ schur_large atol = 1e-8
+
         # Test error handling
         @test_throws ArgumentError predict(dist_lrd, x1, [0, 1, 2], [3, 4, 5])  # out of bounds
         @test_throws ArgumentError predict(dist_lrd, x1, [1, 2, 3], [n + 1, n + 2, n + 3])  # out of bounds


### PR DESCRIPTION
Closes #16

## Problem

`predict(::LRDMvNormal, x, input_indices, output_indices)` returned the correct conditional mean but an incorrect conditional covariance (wrong by up to ~5.0 absolute on a 20-dim example, verified via analytic Schur complement, Woodbury derivation, and Monte Carlo).

## Correct formula

For a joint LRD covariance `Σ = FF' + D` partitioned into input (1) and output (2) blocks, with `M = I + F₁ᵀ D₁⁻¹ F₁`, the Woodbury identity gives `F₁ᵀ Σ₁₁⁻¹ F₁ = I − M⁻¹`, so the conditional (Schur-complement) covariance is:

    Σ_cond = Σ₂₂ − Σ₂₁ Σ₁₁⁻¹ Σ₁₂ = F₂ M⁻¹ F₂ᵀ + Diagonal(D₂)

## The two bugs in the old code

The old code computed `F₂ (I − M⁻¹) F₂' + D₂ + diag(F₂ M⁻¹ F₂')`, which had:
1. The inverse flipped — it used `I − M⁻¹` instead of `M⁻¹`.
2. A double-counted diagonal — it added `diag(F₂ M⁻¹ F₂')` on top of `D₂`.

## The fix

Build a matrix square root `C` of `M⁻¹` (so `C C' = M⁻¹`) via an eigendecomposition with eigenvalues clamped at zero for floating-point robustness. Then `F_cond = F₂ C` reconstructs `F₂ M⁻¹ F₂'` and `D_cond = D₂`. The existing return-type branching is preserved (MvNormal when `length(output) <= rank`, otherwise LRDMvNormal).

## Tests

Two new assertions in `test/test_prediction.jl` compare `cov(predict(...))` against the analytic Schur complement `Σ₂₂ − Σ₂₁ Σ₁₁⁻¹ Σ₁₂` computed from the full `cov(dist)`, using interleaved indices (input `[1,3,5,7,9]`, output `[2,4,...]`) to catch index-mixing bugs, at `atol=1e-8`:
- MvNormal branch: `output=[2,4,6,8,10]` (length ≤ rank), asserts return type is MvNormal and `cov ≈ schur`.
- LRDMvNormal branch: `output=[2,4,...,20]` (length > rank), asserts return type is LRDMvNormal and `cov ≈ schur`.

Both tests were confirmed to fail on the unmodified code and pass after the fix. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)