### PR TITLE
perf: compute only top-rank principal directions in PCAEM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
 /examples/Manifest.toml
+/.worktrees/

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GaussianMixtures = "cc18c42c-b769-54ff-9e2a-b28141a64aae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -19,13 +18,13 @@ Clustering = "0.15.8"
 Distributions = "0.25.120"
 GaussianMixtures = "0.3.13"
 LinearAlgebra = "1.11.0"
-MultivariateStats = "0.10.3"
 Random = "1.11.0"
 Statistics = "1.11.1"
 julia = "1.6.7"
 
 [extras]
+MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["MultivariateStats", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Arec Jamgochian <arec.jamgochian@terraai.earth> and contributors"]
 version = "0.1.0"
 
 [deps]
+Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GaussianMixtures = "cc18c42c-b769-54ff-9e2a-b28141a64aae"
@@ -13,6 +14,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+Arpack = "0.5.4"
 Clustering = "0.15.8"
 Distributions = "0.25.120"
 GaussianMixtures = "0.3.13"

--- a/src/StructuredGaussianMixtures.jl
+++ b/src/StructuredGaussianMixtures.jl
@@ -8,6 +8,7 @@ using Statistics
 using Random
 using MultivariateStats:
     PCA, fit as pca_fit, predict as pca_predict, reconstruct, projection, mean
+using Arpack: eigs
 using GaussianMixtures
 import GaussianMixtures: covar
 using Clustering

--- a/src/StructuredGaussianMixtures.jl
+++ b/src/StructuredGaussianMixtures.jl
@@ -6,8 +6,6 @@ using Distributions
 using LinearAlgebra
 using Statistics
 using Random
-using MultivariateStats:
-    PCA, fit as pca_fit, predict as pca_predict, reconstruct, projection, mean
 using Arpack: eigs
 using GaussianMixtures
 import GaussianMixtures: covar

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -109,23 +109,21 @@ struct PCAEM <: GMMFitMethod
     end
 end
 
-"""
-    _truncated_pca(x, rank)
-
-Compute only the top-`rank` principal directions of `x` (features × samples) and
-return the loadings `P` (features × rank, orthonormal columns) and the data mean `μ`.
-
-Rather than computing a full eigen/SVD and truncating, this eigendecomposes whichever
-Gram matrix is smaller: the `d × d` covariance when `d <= n`, or the `n × n` Gram
-matrix `Z'Z` when `d > n` (recovering the feature-space loadings via `Z * W`). This
-avoids the wasted work of a full decomposition when `rank ≪ min(d, n)`.
-
-For small problems (`min(d, n)` small, or `rank` close to `min(d, n)`), Arpack's
-iterative `eigs` has high overhead and requires `nev < size - 1`, so a dense
-`eigen` is used and truncated instead. Both paths return mathematically equivalent
-results (loadings are defined up to per-column sign / rotation within tied
-eigenvalues).
-"""
+# _truncated_pca(x, rank)
+#
+# Compute only the top-`rank` principal directions of `x` (features × samples) and
+# return the loadings `P` (features × rank, orthonormal columns) and the data mean `μ`.
+#
+# Rather than computing a full eigen/SVD and truncating, this eigendecomposes whichever
+# Gram matrix is smaller: the `d × d` covariance when `d <= n`, or the `n × n` Gram
+# matrix `Z'Z` when `d > n` (recovering the feature-space loadings via `Z * W`). This
+# avoids the wasted work of a full decomposition when `rank ≪ min(d, n)`.
+#
+# For small problems (`min(d, n)` small, or `rank` close to `min(d, n)`), Arpack's
+# iterative `eigs` has high overhead and requires `nev < size - 1`, so a dense
+# `eigen` is used and truncated instead. Both paths return mathematically equivalent
+# results (loadings are defined up to per-column sign / rotation within tied
+# eigenvalues).
 function _truncated_pca(x::AbstractMatrix, rank::Int)
     d, n = size(x)
     μ = vec(Statistics.mean(x; dims=2))

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -110,6 +110,55 @@ struct PCAEM <: GMMFitMethod
 end
 
 """
+    _truncated_pca(x, rank)
+
+Compute only the top-`rank` principal directions of `x` (features × samples) and
+return the loadings `P` (features × rank, orthonormal columns) and the data mean `μ`.
+
+Rather than computing a full eigen/SVD and truncating, this eigendecomposes whichever
+Gram matrix is smaller: the `d × d` covariance when `d <= n`, or the `n × n` Gram
+matrix `Z'Z` when `d > n` (recovering the feature-space loadings via `Z * W`). This
+avoids the wasted work of a full decomposition when `rank ≪ min(d, n)`.
+
+For small problems (`min(d, n)` small, or `rank` close to `min(d, n)`), Arpack's
+iterative `eigs` has high overhead and requires `nev < size - 1`, so a dense
+`eigen` is used and truncated instead. Both paths return mathematically equivalent
+results (loadings are defined up to per-column sign / rotation within tied
+eigenvalues).
+"""
+function _truncated_pca(x::AbstractMatrix, rank::Int)
+    d, n = size(x)
+    μ = vec(Statistics.mean(x; dims=2))
+    Z = x .- μ
+    smaller = min(d, n)
+    use_dense = smaller <= 100 || rank >= smaller - 1
+
+    if d <= n
+        C = Symmetric((Z * Z') ./ (n - 1))          # d × d covariance
+        if use_dense
+            F = eigen(C)
+            idx = sortperm(F.values; rev=true)[1:rank]
+            P = F.vectors[:, idx]
+        else
+            _, V = eigs(C; nev=rank, which=:LR)
+            P = V
+        end
+    else
+        G = Symmetric((Z' * Z) ./ (n - 1))          # n × n Gram (cheap when d > n)
+        if use_dense
+            F = eigen(G)
+            idx = sortperm(F.values; rev=true)[1:rank]
+            W = F.vectors[:, idx]
+        else
+            _, W = eigs(G; nev=rank, which=:LR)
+        end
+        U = Z * W
+        P = U ./ sqrt.(sum(abs2, U; dims=1))         # unit-norm feature-space loadings
+    end
+    return P, μ
+end
+
+"""
     fit(fitmethod::PCAEM, x::Matrix)
 
 This method first performs PCA to reduce dimensionality, then fits a GMM in the reduced space,
@@ -135,14 +184,11 @@ function fit(fitmethod::PCAEM, x::Matrix)
         ),
     )
 
-    # run PCA on x
-    pca = pca_fit(PCA, x; maxoutdim=fitmethod.rank)
-    reduced_data = pca_predict(pca, x)
-    reconstructed_data = reconstruct(pca, reduced_data)
-    error_data = x .- reconstructed_data
-    D = vec(var(error_data; dims=2))
-    μ = mean(pca)
-    P = projection(pca)
+    # compute only the top-rank principal directions and the data mean
+    P, μ = _truncated_pca(x, fitmethod.rank)
+    reduced_data = P' * (x .- μ)
+    reconstructed_data = P * reduced_data .+ μ
+    D = vec(var(x .- reconstructed_data; dims=2))
 
     # fit GMM on the PCA scores
     gmm = GMM(

--- a/test/test_fitting.jl
+++ b/test/test_fitting.jl
@@ -4,6 +4,8 @@ using Random
 using Distributions
 using StructuredGaussianMixtures
 using GaussianMixtures
+using Statistics
+using MultivariateStats: PCA, fit as pca_fit, projection, mean as pca_mean, predict as pca_predict, reconstruct
 
 @testset "Fitting Methods" begin
     # Set random seed for reproducibility
@@ -93,6 +95,116 @@ using GaussianMixtures
         # Test with rank larger than n_features
         pcaem_large_rank = PCAEM(2, n_features + 5)
         @test_throws ArgumentError StructuredGaussianMixtures.fit(pcaem_large_rank, X)
+    end
+
+    @testset "Truncated PCA equivalence" begin
+        # The truncated PCA helper must reproduce what PCAEM actually uses from a
+        # full PCA: the top-rank reconstruction subspace and the reconstruction-error
+        # diagonal. Loadings are only defined up to per-column sign / rotation within
+        # tied eigenvalues, so we assert sign/rotation-invariant quantities only.
+
+        # d <= n branch (eigendecompose the d x d covariance)
+        for (d, n, rank) in [(20, 1000, 5), (20, 1000, 6)]
+            data = randn(d, n)
+
+            P_trunc, μ_trunc = StructuredGaussianMixtures._truncated_pca(data, rank)
+            @test size(P_trunc) == (d, rank)
+
+            pca = pca_fit(PCA, data; maxoutdim=rank)
+            P_full = projection(pca)
+            μ_full = pca_mean(pca)
+
+            # Means match exactly
+            @test μ_trunc ≈ μ_full atol = 1e-10
+
+            # Reconstruction subspace (projector onto top-rank subspace) matches
+            @test P_trunc * P_trunc' ≈ P_full * P_full' atol = 1e-8
+
+            # Reconstruction-error variance diagonal D matches
+            reduced_trunc = P_trunc' * (data .- μ_trunc)
+            recon_trunc = P_trunc * reduced_trunc .+ μ_trunc
+            D_trunc = vec(var(data .- recon_trunc; dims=2))
+
+            reduced_full = pca_predict(pca, data)
+            recon_full = reconstruct(pca, reduced_full)
+            D_full = vec(var(data .- recon_full; dims=2))
+
+            @test D_trunc ≈ D_full atol = 1e-8
+        end
+
+        # d <= n branch, large enough to exercise Arpack's iterative eigs path
+        # (smaller dimension > 100 so it does not hit the dense fallback)
+        let d = 150, n = 400, rank = 5
+            data = randn(d, n)
+            P_trunc, μ_trunc = StructuredGaussianMixtures._truncated_pca(data, rank)
+            @test size(P_trunc) == (d, rank)
+
+            pca = pca_fit(PCA, data; maxoutdim=rank)
+            P_full = projection(pca)
+            μ_full = pca_mean(pca)
+
+            @test μ_trunc ≈ μ_full atol = 1e-10
+            @test P_trunc * P_trunc' ≈ P_full * P_full' atol = 1e-8
+
+            reduced_trunc = P_trunc' * (data .- μ_trunc)
+            recon_trunc = P_trunc * reduced_trunc .+ μ_trunc
+            D_trunc = vec(var(data .- recon_trunc; dims=2))
+
+            reduced_full = pca_predict(pca, data)
+            recon_full = reconstruct(pca, reduced_full)
+            D_full = vec(var(data .- recon_full; dims=2))
+
+            @test D_trunc ≈ D_full atol = 1e-8
+        end
+
+        # d > n branch, large enough to exercise Arpack's iterative eigs path on the
+        # smaller n x n Gram matrix (smaller dimension > 100)
+        let d = 400, n = 150, rank = 5
+            data = randn(d, n)
+            P_trunc, μ_trunc = StructuredGaussianMixtures._truncated_pca(data, rank)
+            @test size(P_trunc) == (d, rank)
+
+            pca = pca_fit(PCA, data; maxoutdim=rank)
+            P_full = projection(pca)
+            μ_full = pca_mean(pca)
+
+            @test μ_trunc ≈ μ_full atol = 1e-10
+            @test P_trunc * P_trunc' ≈ P_full * P_full' atol = 1e-8
+
+            reduced_trunc = P_trunc' * (data .- μ_trunc)
+            recon_trunc = P_trunc * reduced_trunc .+ μ_trunc
+            D_trunc = vec(var(data .- recon_trunc; dims=2))
+
+            reduced_full = pca_predict(pca, data)
+            recon_full = reconstruct(pca, reduced_full)
+            D_full = vec(var(data .- recon_full; dims=2))
+
+            @test D_trunc ≈ D_full atol = 1e-8
+        end
+
+        # d > n branch (dense fallback path, smaller n x n Gram matrix)
+        let d = 200, n = 30, rank = 5
+            data = randn(d, n)
+            P_trunc, μ_trunc = StructuredGaussianMixtures._truncated_pca(data, rank)
+            @test size(P_trunc) == (d, rank)
+
+            pca = pca_fit(PCA, data; maxoutdim=rank)
+            P_full = projection(pca)
+            μ_full = pca_mean(pca)
+
+            @test μ_trunc ≈ μ_full atol = 1e-10
+            @test P_trunc * P_trunc' ≈ P_full * P_full' atol = 1e-8
+
+            reduced_trunc = P_trunc' * (data .- μ_trunc)
+            recon_trunc = P_trunc * reduced_trunc .+ μ_trunc
+            D_trunc = vec(var(data .- recon_trunc; dims=2))
+
+            reduced_full = pca_predict(pca, data)
+            recon_full = reconstruct(pca, reduced_full)
+            D_full = vec(var(data .- recon_full; dims=2))
+
+            @test D_trunc ≈ D_full atol = 1e-8
+        end
     end
 
     @testset "FactorEM" begin


### PR DESCRIPTION
Closes #18

## Problem

`PCAEM.fit` called `pca_fit(PCA, x; maxoutdim=rank)`. `maxoutdim` only **truncates** an already-computed full decomposition; it does not make MultivariateStats compute fewer components. For `d < n` PCA does a full `eigen` of the `d x d` covariance, and for `d >= n` a full `svd` of the centered data. When `rank` is far smaller than `min(d, n)`, almost all of that work is wasted.

## Approach

`PCAEM.fit` only needs two things from PCA: the loadings `P` (d x rank) and the mean `mu`. Everything downstream (reduced data, reconstruction, and the diagonal noise `D`) derives from those.

The new `_truncated_pca` helper eigendecomposes only whichever **Gram matrix is smaller**:

- **`d <= n` branch:** eigendecompose the `d x d` covariance `Symmetric((Z Z') / (n-1))` and take the top-`rank` eigenvectors as `P`.
- **`d > n` branch:** eigendecompose the smaller `n x n` Gram matrix `Symmetric((Z' Z) / (n-1))`, then recover feature-space loadings via `U = Z W` and normalize columns.

Choosing the smaller matrix by the `d <= n` branch is essential: eigendecomposing the larger Gram matrix is catastrophically slow (e.g. `eigs(ZZ')` on d=20000, n=1000 is ~12x slower than baseline).

### Small-dimension dense fallback

When the smaller dimension is small, Arpack's iterative `eigs` has high overhead (and can fail to converge), and `eigs` requires `nev < size - 1`. The helper falls back to a dense `eigen` + truncation when `min(d, n) <= 100` or `rank >= min(d, n) - 1`. The existing PCAEM tests (d=20, n=1000) and edge cases hit this fallback, which is correct and expected. The existing `rank <= n_features` `ArgumentError` check is preserved.

### New dependency

Adds `Arpack` (`eigs`) to `[deps]` and `[compat]`.

## Equivalence tests

Added a "Truncated PCA equivalence" testset in `test/test_fitting.jl` verifying, against `pca_fit(PCA, x; maxoutdim=rank)`, that:

- The mean `mu` matches (~1e-10).
- The reconstruction subspace projector `P*P'` matches `P_full*P_full'` (sign/rotation-invariant) to ~1e-8.
- The reconstruction-error variance diagonal `D` matches to ~1e-8.

These cover both branches and both the dense-fallback path (d=20/n=1000, d=200/n=30) and the iterative `eigs` path (d=150/n=400, d=400/n=150). Loadings are only defined up to per-column sign / rotation, so only sign/rotation-invariant quantities are asserted. The existing PCAEM testset (LRDMvNormal components, correct rank, finite logpdf, valid weights) and edge-case tests remain unchanged and pass.

## Results

Full suite passes: LRDMvNormal 53/53, Fitting Methods 104/104, Prediction and Marginal Functions 24/24. (Unrelated GaussianMixtures "Too low occupancy" warnings are expected.) Sanity benchmark on d=5000, n=800, rank=5 showed ~9x speedup vs the full PCA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)